### PR TITLE
Add --name argument for switching between different credentials

### DIFF
--- a/op_env/_cli.py
+++ b/op_env/_cli.py
@@ -60,11 +60,11 @@ class AppendListFromYAMLAction(argparse.Action):
 
 
 def add_environment_arguments(arg_parser: argparse.ArgumentParser) -> None:
-    arg_parser.add_argument('--name', '-n',
-                            metavar='NAME',
+    arg_parser.add_argument('--title', '-t',
+                            metavar='TITLE',
                             action='append',
                             default=[],
-                            help='name of 1Password item from which all tagged environment '
+                            help='title of 1Password item from which all tagged environment '
                             'variable names will be set')
     arg_parser.add_argument('--environment', '-e',
                             metavar='ENVVAR',

--- a/op_env/_cli.py
+++ b/op_env/_cli.py
@@ -60,6 +60,12 @@ class AppendListFromYAMLAction(argparse.Action):
 
 
 def add_environment_arguments(arg_parser: argparse.ArgumentParser) -> None:
+    arg_parser.add_argument('--name', '-n',
+                            metavar='NAME',
+                            action='append',
+                            default=[],
+                            help='name of 1Password item from which all tagged environment '
+                            'variable names will be set')
     arg_parser.add_argument('--environment', '-e',
                             metavar='ENVVAR',
                             action='append',

--- a/op_env/_cli.py
+++ b/op_env/_cli.py
@@ -5,17 +5,18 @@ import os
 import pipes
 import subprocess
 import sys
-from typing import Any, List, Optional, Sequence, Union
+from typing import Any, cast, Dict, List, Optional, Sequence, Union
 
 from typing_extensions import TypedDict
 import yaml
 
-from .op import do_env_lookups, EnvVarName
+from .op import do_lookups, EnvVarName, Title
 
 
 class Arguments(TypedDict):
     operation: str
     environment: List[EnvVarName]
+    title: List[Title]
     command: List[str]
 
 
@@ -118,16 +119,16 @@ def parse_argv(argv: List[str]) -> Arguments:
 def process_args(args: Arguments) -> int:
     if args['operation'] == 'run':
         copied_env = dict(os.environ)
-        new_env = do_env_lookups(args['environment'])
-        copied_env.update(new_env)
+        new_env = do_lookups(args['environment'], args['title'])
+        copied_env.update(cast(Dict[str, str], new_env))
         subprocess.check_call(args['command'], env=copied_env)
         return 0
     elif args['operation'] == 'json':
-        new_env = do_env_lookups(args['environment'])
+        new_env = do_lookups(args['environment'], args['title'])
         print(json.dumps(new_env))
         return 0
     elif args['operation'] == 'sh':
-        new_env = do_env_lookups(args['environment'])
+        new_env = do_lookups(args['environment'], args['title'])
         for envvar, envvalue in new_env.items():
             print(f'{envvar}={pipes.quote(envvalue)}; export {envvar}')
         return 0

--- a/op_env/_cli.py
+++ b/op_env/_cli.py
@@ -10,7 +10,7 @@ from typing import Any, List, Optional, Sequence, Union
 from typing_extensions import TypedDict
 import yaml
 
-from .op import do_smart_lookups, EnvVarName
+from .op import do_env_lookups, EnvVarName
 
 
 class Arguments(TypedDict):
@@ -118,16 +118,16 @@ def parse_argv(argv: List[str]) -> Arguments:
 def process_args(args: Arguments) -> int:
     if args['operation'] == 'run':
         copied_env = dict(os.environ)
-        new_env = do_smart_lookups(args['environment'])
+        new_env = do_env_lookups(args['environment'])
         copied_env.update(new_env)
         subprocess.check_call(args['command'], env=copied_env)
         return 0
     elif args['operation'] == 'json':
-        new_env = do_smart_lookups(args['environment'])
+        new_env = do_env_lookups(args['environment'])
         print(json.dumps(new_env))
         return 0
     elif args['operation'] == 'sh':
-        new_env = do_smart_lookups(args['environment'])
+        new_env = do_env_lookups(args['environment'])
         for envvar, envvalue in new_env.items():
             print(f'{envvar}={pipes.quote(envvalue)}; export {envvar}')
         return 0

--- a/op_env/op.py
+++ b/op_env/op.py
@@ -114,6 +114,10 @@ def _get_fields_from_list_output(list_items_output: OpListItemsOutputOrderedByEn
     }
 
 
+def _get_fields_from_title(title: Title) -> Dict[EnvVarName, FieldValue]:
+    raise NotImplementedError('Implement _op_env_var_names_from_title')
+
+
 def _last_underscored_component_lowercased(env_var_name: EnvVarName) -> FieldName:
     components = env_var_name.split('_')
     return FieldName(components[-1].lower())
@@ -195,14 +199,12 @@ def _do_env_lookups(env_var_names: List[EnvVarName]) -> Dict[EnvVarName, FieldVa
     }
 
 
-def _env_var_names_from_item(title: Title) -> List[EnvVarName]:
-    raise NotImplementedError('Teach me how to look up tags')
-
-
 def _do_title_lookups(titles: List[Title]) -> Mapping[EnvVarName, FieldValue]:
-    if len(titles) != 0:
-        raise NotImplementedError('Teach me to handle titles')
-    return {}
+    title_lookups: Dict[EnvVarName, FieldValue] = {}
+    for title in titles:
+        fields_by_env_name: Dict[EnvVarName, FieldValue] = _get_fields_from_title(title)
+        title_lookups.update(fields_by_env_name)
+    return title_lookups
 
 
 def do_lookups(env_var_names: List[EnvVarName],

--- a/op_env/op.py
+++ b/op_env/op.py
@@ -67,10 +67,10 @@ def _op_list_items(env_var_names: List[EnvVarName]) -> OpListItemsOpaqueOutput:
     return OpListItemsOpaqueOutput(ordered_list_items_data)
 
 
-def _op_get_item_from_list_output(list_items_output: OpListItemsOpaqueOutput,
-                                  env_var_names: Collection[EnvVarName],
-                                  all_fields_to_seek: Collection[FieldName]) ->\
-                                  Dict[EnvVarName, Dict[FieldName, FieldValue]]:
+def _get_fields_from_list_output(list_items_output: OpListItemsOpaqueOutput,
+                                 env_var_names: Collection[EnvVarName],
+                                 all_fields_to_seek: Collection[FieldName]) ->\
+                                 Dict[EnvVarName, Dict[FieldName, FieldValue]]:
     sorted_fields_to_seek = sorted(all_fields_to_seek)
     get_command: List[str] = ['op', 'get', 'item', '-', '--fields',
                               ','.join(sorted_fields_to_seek)]
@@ -162,9 +162,9 @@ def _do_env_lookups(env_var_names: List[EnvVarName]) -> Dict[EnvVarName, FieldVa
     _validate_env_var_names(env_var_names)
     list_items_output = _op_list_items(env_var_names)
     all_fields_to_seek = _op_consolidated_fields(env_var_names)
-    field_values_for_envvars = _op_get_item_from_list_output(list_items_output,
-                                                             env_var_names,
-                                                             all_fields_to_seek)
+    field_values_for_envvars = _get_fields_from_list_output(list_items_output,
+                                                            env_var_names,
+                                                            all_fields_to_seek)
     return {
         env_var_name: _op_pluck_correct_field(env_var_name, field_values_for_envvars[env_var_name])
         for env_var_name in field_values_for_envvars

--- a/op_env/op.py
+++ b/op_env/op.py
@@ -157,7 +157,7 @@ def validate_env_var_names(env_var_names: List[EnvVarName]) -> None:
             raise InvalidTagOPLookupError('1Password does not support tags with commas')
 
 
-def do_smart_lookups(env_var_names: List[EnvVarName]) -> Dict[str, str]:
+def do_env_lookups(env_var_names: List[EnvVarName]) -> Dict[str, str]:
     validate_env_var_names(env_var_names)
     list_items_output = _op_list_items(env_var_names)
     all_fields_to_seek = _op_consolidated_fields(env_var_names)

--- a/op_env/op.py
+++ b/op_env/op.py
@@ -1,11 +1,12 @@
 from collections import OrderedDict
 import json
 import subprocess
-from typing import Any, Collection, Dict, List, NewType, Sequence, Set, TypeVar
+from typing import Any, Collection, Dict, List, Mapping, NewType, Sequence, Set, TypeVar
 
 from typing_extensions import TypedDict
 
 EnvVarName = NewType('EnvVarName', str)
+Title = NewType('Title', str)
 
 
 class OpListItemsEntryOverview(TypedDict, total=False):
@@ -151,14 +152,14 @@ def _op_pluck_correct_field(env_var_name: EnvVarName,
                                     'one of these fields in 1Password.')
 
 
-def validate_env_var_names(env_var_names: List[EnvVarName]) -> None:
+def _validate_env_var_names(env_var_names: List[EnvVarName]) -> None:
     for env_var_name in env_var_names:
         if ',' in env_var_name:
             raise InvalidTagOPLookupError('1Password does not support tags with commas')
 
 
-def do_env_lookups(env_var_names: List[EnvVarName]) -> Dict[str, str]:
-    validate_env_var_names(env_var_names)
+def _do_env_lookups(env_var_names: List[EnvVarName]) -> Dict[EnvVarName, FieldValue]:
+    _validate_env_var_names(env_var_names)
     list_items_output = _op_list_items(env_var_names)
     all_fields_to_seek = _op_consolidated_fields(env_var_names)
     field_values_for_envvars = _op_get_item(list_items_output,
@@ -168,3 +169,20 @@ def do_env_lookups(env_var_names: List[EnvVarName]) -> Dict[str, str]:
         env_var_name: _op_pluck_correct_field(env_var_name, field_values_for_envvars[env_var_name])
         for env_var_name in field_values_for_envvars
     }
+
+
+def _env_var_names_from_item(title: Title) -> List[EnvVarName]:
+    raise NotImplementedError('Teach me how to look up tags')
+
+
+def _do_title_lookups(titles: List[Title]) -> Mapping[EnvVarName, FieldValue]:
+    if len(titles) != 0:
+        raise NotImplementedError('Teach me to handle titles')
+    return {}
+
+
+def do_lookups(env_var_names: List[EnvVarName],
+               titles: List[Title]) -> Dict[EnvVarName, FieldValue]:
+    env_lookups = _do_env_lookups(env_var_names)
+    title_lookups = _do_title_lookups(titles)
+    return {**env_lookups, **title_lookups}

--- a/op_env/op.py
+++ b/op_env/op.py
@@ -67,10 +67,10 @@ def _op_list_items(env_var_names: List[EnvVarName]) -> OpListItemsOpaqueOutput:
     return OpListItemsOpaqueOutput(ordered_list_items_data)
 
 
-def _op_get_item(list_items_output: OpListItemsOpaqueOutput,
-                 env_var_names: Collection[EnvVarName],
-                 all_fields_to_seek: Collection[FieldName]) ->\
-                 Dict[EnvVarName, Dict[FieldName, FieldValue]]:
+def _op_get_item_from_list_output(list_items_output: OpListItemsOpaqueOutput,
+                                  env_var_names: Collection[EnvVarName],
+                                  all_fields_to_seek: Collection[FieldName]) ->\
+                                  Dict[EnvVarName, Dict[FieldName, FieldValue]]:
     sorted_fields_to_seek = sorted(all_fields_to_seek)
     get_command: List[str] = ['op', 'get', 'item', '-', '--fields',
                               ','.join(sorted_fields_to_seek)]
@@ -162,9 +162,9 @@ def _do_env_lookups(env_var_names: List[EnvVarName]) -> Dict[EnvVarName, FieldVa
     _validate_env_var_names(env_var_names)
     list_items_output = _op_list_items(env_var_names)
     all_fields_to_seek = _op_consolidated_fields(env_var_names)
-    field_values_for_envvars = _op_get_item(list_items_output,
-                                            env_var_names,
-                                            all_fields_to_seek)
+    field_values_for_envvars = _op_get_item_from_list_output(list_items_output,
+                                                             env_var_names,
+                                                             all_fields_to_seek)
     return {
         env_var_name: _op_pluck_correct_field(env_var_name, field_values_for_envvars[env_var_name])
         for env_var_name in field_values_for_envvars

--- a/op_env/op.py
+++ b/op_env/op.py
@@ -17,6 +17,8 @@ class OpListItemsEntry(TypedDict, total=False):
     overview: OpListItemsEntryOverview
 
 
+# 'op list items' output comes as a JSON list of items that matched
+# the query.
 OpListItemsOpaqueOutput = NewType('OpListItemsOpaqueOutput', List[Any])
 
 FieldName = NewType('FieldName', str)
@@ -71,6 +73,12 @@ def _get_fields_from_list_output(list_items_output: OpListItemsOpaqueOutput,
                                  env_var_names: Collection[EnvVarName],
                                  all_fields_to_seek: Collection[FieldName]) ->\
                                  Dict[EnvVarName, Dict[FieldName, FieldValue]]:
+    #
+    # 'op get item' with the '--fields' flag will take the JSON list
+    # of items structure from 'op list items' and return JSON objects
+    # separated by newlines of the fields requested if they exist in
+    # the item
+    #
     sorted_fields_to_seek = sorted(all_fields_to_seek)
     get_command: List[str] = ['op', 'get', 'item', '-', '--fields',
                               ','.join(sorted_fields_to_seek)]

--- a/op_env/op.py
+++ b/op_env/op.py
@@ -81,10 +81,10 @@ def _op_list_items(env_var_names: List[EnvVarName]) -> OpListItemsOutputOrderedB
     return OpListItemsOutputOrderedByEnvVarName(ordered_list_items_data)
 
 
-def _get_fields_from_list_output(list_items_output: OpListItemsOutputOrderedByEnvVarName,
-                                 env_var_names: Collection[EnvVarName],
-                                 all_fields_to_seek: Collection[FieldName]) ->\
-                                 Dict[EnvVarName, Dict[FieldName, FieldValue]]:
+def _fields_from_list_output(list_items_output: OpListItemsOutputOrderedByEnvVarName,
+                             env_var_names: Collection[EnvVarName],
+                             all_fields_to_seek: Collection[FieldName]) ->\
+                               Dict[EnvVarName, Dict[FieldName, FieldValue]]:
     #
     # 'op get item' with the '--fields' flag will take the JSON list
     # of items structure from 'op list items' and return JSON objects
@@ -114,7 +114,7 @@ def _get_fields_from_list_output(list_items_output: OpListItemsOutputOrderedByEn
     }
 
 
-def _get_fields_from_title(title: Title) -> Dict[EnvVarName, FieldValue]:
+def _fields_from_title(title: Title) -> Dict[EnvVarName, FieldValue]:
     raise NotImplementedError('Implement _op_env_var_names_from_title')
 
 
@@ -190,9 +190,9 @@ def _do_env_lookups(env_var_names: List[EnvVarName]) -> Dict[EnvVarName, FieldVa
     list_items_output = _op_list_items(env_var_names)
     all_fields_to_seek = _op_consolidated_fields(env_var_names)
     field_values_for_envvars: Dict[EnvVarName, Dict[FieldName, FieldValue]] = \
-        _get_fields_from_list_output(list_items_output,
-                                     env_var_names,
-                                     all_fields_to_seek)
+        _fields_from_list_output(list_items_output,
+                                 env_var_names,
+                                 all_fields_to_seek)
     return {
         env_var_name: _op_pluck_correct_field(env_var_name, field_values_for_envvars[env_var_name])
         for env_var_name in field_values_for_envvars
@@ -202,7 +202,7 @@ def _do_env_lookups(env_var_names: List[EnvVarName]) -> Dict[EnvVarName, FieldVa
 def _do_title_lookups(titles: List[Title]) -> Mapping[EnvVarName, FieldValue]:
     title_lookups: Dict[EnvVarName, FieldValue] = {}
     for title in titles:
-        fields_by_env_name: Dict[EnvVarName, FieldValue] = _get_fields_from_title(title)
+        fields_by_env_name: Dict[EnvVarName, FieldValue] = _fields_from_title(title)
         title_lookups.update(fields_by_env_name)
     return title_lookups
 

--- a/tests/test_op_env.py
+++ b/tests/test_op_env.py
@@ -112,7 +112,7 @@ def two_item_text_file():
 
 @patch('op_env.op._op_list_items', autospec=op_env.op._op_list_items)
 @patch('op_env.op._op_consolidated_fields', autospec=op_env.op._op_consolidated_fields)
-@patch('op_env.op._op_get_item', autospec=op_env.op._op_get_item)
+@patch('op_env.op._op_get_item_from_list_output', autospec=op_env.op._op_get_item_from_list_output)
 @patch('op_env.op._op_pluck_correct_field', autospec=op_env.op._op_pluck_correct_field)
 @patch('sys.stdout', new_callable=io.StringIO)
 def test_process_args_shows_json_with_simple_env(stdout_stringio,

--- a/tests/test_op_env.py
+++ b/tests/test_op_env.py
@@ -112,7 +112,7 @@ def two_item_text_file():
 
 @patch('op_env.op._op_list_items', autospec=op_env.op._op_list_items)
 @patch('op_env.op._op_consolidated_fields', autospec=op_env.op._op_consolidated_fields)
-@patch('op_env.op._op_get_item_from_list_output', autospec=op_env.op._op_get_item_from_list_output)
+@patch('op_env.op._get_fields_from_list_output', autospec=op_env.op._get_fields_from_list_output)
 @patch('op_env.op._op_pluck_correct_field', autospec=op_env.op._op_pluck_correct_field)
 @patch('sys.stdout', new_callable=io.StringIO)
 def test_process_args_shows_json_with_simple_env(stdout_stringio,

--- a/tests/test_op_env.py
+++ b/tests/test_op_env.py
@@ -405,7 +405,35 @@ def test_parse_args_json_operation_no_env_variables():
     argv = ['op-env', 'json']
     args = parse_argv(argv)
     assert args == {'environment': [],
+                    'name': [],
                     'operation': 'json'}
+
+
+def test_parse_args_run_operation_with_long_name_specified():
+    argv = ['op-env', 'run', '--name', 'foo:bar', 'mycmd']
+    args = parse_argv(argv)
+    assert args == {'command': ['mycmd'],
+                    'environment': [],
+                    'name': ['foo:bar'],
+                    'operation': 'run'}
+
+
+def test_parse_args_run_operation_with_multiple_name_specified():
+    argv = ['op-env', 'run', '-n', 'foo: bar', '-n' 'bing: baz', 'mycmd']
+    args = parse_argv(argv)
+    assert args == {'command': ['mycmd'],
+                    'name': ['foo: bar', 'bing: baz'],
+                    'environment': [],
+                    'operation': 'run'}
+
+
+def test_parse_args_run_operation_with_name_specified():
+    argv = ['op-env', 'run', '-n', 'foo: bar', 'mycmd']
+    args = parse_argv(argv)
+    assert args == {'command': ['mycmd'],
+                    'name': ['foo: bar'],
+                    'environment': [],
+                    'operation': 'run'}
 
 
 def test_parse_args_run_operation_with_long_env_variables():
@@ -413,6 +441,7 @@ def test_parse_args_run_operation_with_long_env_variables():
     args = parse_argv(argv)
     assert args == {'command': ['mycmd'],
                     'environment': ['DUMMY', 'DUMMY2'],
+                    'name': [],
                     'operation': 'run'}
 
 
@@ -421,6 +450,7 @@ def test_parse_args_run_operation_no_env_variables():
     args = parse_argv(argv)
     assert args == {'command': ['mycmd'],
                     'environment': [],
+                    'name': [],
                     'operation': 'run'}
 
 
@@ -429,6 +459,7 @@ def test_parse_args_run_operation_with_multiple_environment_arguments():
     args = parse_argv(argv)
     assert args == {'command': ['mycmd'],
                     'environment': ['DUMMY', 'DUMMY2'],
+                    'name': [],
                     'operation': 'run'}
 
 
@@ -437,6 +468,7 @@ def test_parse_args_run_operation_with_environment_arguments():
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['DUMMY'],
+                    'name': [],
                     'operation': 'run'}
 
 
@@ -448,6 +480,7 @@ def test_parse_args_run_operation_with_multiple_yaml_and_environment_arguments(o
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['VAR_1', 'VAR0', 'VAR1', 'VAR2', 'VARA'],
+                    'name': [],
                     'operation': 'run'}
 
 
@@ -456,6 +489,7 @@ def test_parse_args_run_operation_with_yaml_arguments_and_environment_arguments(
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['VAR0', 'VAR1', 'VAR2'],
+                    'name': [],
                     'operation': 'run'}
 
 
@@ -471,6 +505,7 @@ def test_parse_args_run_operation_with_yaml_arguments_and_text_environment_argum
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['VAR0', 'VAR1', 'VAR2', 'TVAR1', 'TVAR2'],
+                    'name': [],
                     'operation': 'run'}
 
 
@@ -479,6 +514,7 @@ def test_parse_args_run_operation_with_text_arguments_and_environment_arguments(
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['VAR0', 'TVAR1', 'TVAR2'],
+                    'name': [],
                     'operation': 'run'}
 
 
@@ -518,6 +554,7 @@ def test_parse_args_run_operation_with_empty_file_yaml_argument(empty_file):
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': [],
+                    'name': [],
                     'operation': 'run'}
 
 
@@ -526,6 +563,7 @@ def test_parse_args_run_operation_with_empty_file_text_argument(empty_file):
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': [],
+                    'name': [],
                     'operation': 'run'}
 
 
@@ -534,6 +572,7 @@ def test_parse_args_run_operation_with_text_argument(two_item_text_file):
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['TVAR1', 'TVAR2'],
+                    'name': [],
                     'operation': 'run'}
 
 
@@ -542,19 +581,20 @@ def test_parse_args_run_operation_with_yaml_argument(two_item_yaml_file):
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['VAR1', 'VAR2'],
+                    'name': [],
                     'operation': 'run'}
 
 
 def test_parse_args_run_simple():
     argv = ['op-env', 'run', '-e', 'DUMMY', 'mycmd']
     args = parse_argv(argv)
-    assert args == {'command': ['mycmd'], 'environment': ['DUMMY'], 'operation': 'run'}
+    assert args == {'command': ['mycmd'], 'environment': ['DUMMY'], 'operation': 'run', 'name': []}
 
 
 def test_parse_args_sh_simple():
     argv = ['op-env', 'sh', '-e', 'DUMMY']
     args = parse_argv(argv)
-    assert args == {'environment': ['DUMMY'], 'operation': 'sh'}
+    assert args == {'environment': ['DUMMY'], 'operation': 'sh', 'name': []}
 
 
 @pytest.mark.skip(reason="need to mock op binary in test PATH")
@@ -571,7 +611,7 @@ def test_cli_help_run():
     env.update(os.environ)
     env.update(request_long_lines)
 
-    expected_help = """usage: op-env run [-h] [--environment ENVVAR] [--yaml-environment YAMLENV] \
+    expected_help = """usage: op-env run [-h] [--name NAME] [--environment ENVVAR] [--yaml-environment YAMLENV] \
 [--file-environment FILEENV] command [command ...]
 
 Run the specified command with the given environment variables
@@ -581,6 +621,8 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
+  --name NAME, -n NAME  name of 1Password item from which all tagged environment variable names \
+will be set
   --environment ENVVAR, -e ENVVAR
                         environment variable name to set, based on item with same tag in 1Password
   --yaml-environment YAMLENV, -y YAMLENV
@@ -602,13 +644,15 @@ def test_cli_help_json():
     env = {}
     env.update(os.environ)
     env.update(request_long_lines)
-    expected_help = """usage: op-env json [-h] [--environment ENVVAR] [--yaml-environment YAMLENV] \
+    expected_help = """usage: op-env json [-h] [--name NAME] [--environment ENVVAR] [--yaml-environment YAMLENV] \
 [--file-environment FILEENV]
 
 Produce simple JSON on stdout mapping requested env variables to values
 
 options:
   -h, --help            show this help message and exit
+  --name NAME, -n NAME  name of 1Password item from which all tagged environment variable names \
+will be set
   --environment ENVVAR, -e ENVVAR
                         environment variable name to set, based on item with same tag in 1Password
   --yaml-environment YAMLENV, -y YAMLENV
@@ -630,13 +674,15 @@ def test_cli_help_sh():
     env = {}
     env.update(os.environ)
     env.update(request_long_lines)
-    expected_help = """usage: op-env sh [-h] [--environment ENVVAR] [--yaml-environment YAMLENV] \
+    expected_help = """usage: op-env sh [-h] [--name NAME] [--environment ENVVAR] [--yaml-environment YAMLENV] \
 [--file-environment FILEENV]
 
 Produce commands on stdout that can be 'eval'ed to set variables in current shell
 
 options:
   -h, --help            show this help message and exit
+  --name NAME, -n NAME  name of 1Password item from which all tagged environment variable names \
+will be set
   --environment ENVVAR, -e ENVVAR
                         environment variable name to set, based on item with same tag in 1Password
   --yaml-environment YAMLENV, -y YAMLENV

--- a/tests/test_op_env.py
+++ b/tests/test_op_env.py
@@ -405,33 +405,33 @@ def test_parse_args_json_operation_no_env_variables():
     argv = ['op-env', 'json']
     args = parse_argv(argv)
     assert args == {'environment': [],
-                    'name': [],
+                    'title': [],
                     'operation': 'json'}
 
 
 def test_parse_args_run_operation_with_long_name_specified():
-    argv = ['op-env', 'run', '--name', 'foo:bar', 'mycmd']
+    argv = ['op-env', 'run', '--title', 'foo:bar', 'mycmd']
     args = parse_argv(argv)
     assert args == {'command': ['mycmd'],
                     'environment': [],
-                    'name': ['foo:bar'],
+                    'title': ['foo:bar'],
                     'operation': 'run'}
 
 
 def test_parse_args_run_operation_with_multiple_name_specified():
-    argv = ['op-env', 'run', '-n', 'foo: bar', '-n' 'bing: baz', 'mycmd']
+    argv = ['op-env', 'run', '-t', 'foo: bar', '-t' 'bing: baz', 'mycmd']
     args = parse_argv(argv)
     assert args == {'command': ['mycmd'],
-                    'name': ['foo: bar', 'bing: baz'],
+                    'title': ['foo: bar', 'bing: baz'],
                     'environment': [],
                     'operation': 'run'}
 
 
 def test_parse_args_run_operation_with_name_specified():
-    argv = ['op-env', 'run', '-n', 'foo: bar', 'mycmd']
+    argv = ['op-env', 'run', '-t', 'foo: bar', 'mycmd']
     args = parse_argv(argv)
     assert args == {'command': ['mycmd'],
-                    'name': ['foo: bar'],
+                    'title': ['foo: bar'],
                     'environment': [],
                     'operation': 'run'}
 
@@ -441,7 +441,7 @@ def test_parse_args_run_operation_with_long_env_variables():
     args = parse_argv(argv)
     assert args == {'command': ['mycmd'],
                     'environment': ['DUMMY', 'DUMMY2'],
-                    'name': [],
+                    'title': [],
                     'operation': 'run'}
 
 
@@ -450,7 +450,7 @@ def test_parse_args_run_operation_no_env_variables():
     args = parse_argv(argv)
     assert args == {'command': ['mycmd'],
                     'environment': [],
-                    'name': [],
+                    'title': [],
                     'operation': 'run'}
 
 
@@ -459,7 +459,7 @@ def test_parse_args_run_operation_with_multiple_environment_arguments():
     args = parse_argv(argv)
     assert args == {'command': ['mycmd'],
                     'environment': ['DUMMY', 'DUMMY2'],
-                    'name': [],
+                    'title': [],
                     'operation': 'run'}
 
 
@@ -468,7 +468,7 @@ def test_parse_args_run_operation_with_environment_arguments():
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['DUMMY'],
-                    'name': [],
+                    'title': [],
                     'operation': 'run'}
 
 
@@ -480,7 +480,7 @@ def test_parse_args_run_operation_with_multiple_yaml_and_environment_arguments(o
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['VAR_1', 'VAR0', 'VAR1', 'VAR2', 'VARA'],
-                    'name': [],
+                    'title': [],
                     'operation': 'run'}
 
 
@@ -489,7 +489,7 @@ def test_parse_args_run_operation_with_yaml_arguments_and_environment_arguments(
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['VAR0', 'VAR1', 'VAR2'],
-                    'name': [],
+                    'title': [],
                     'operation': 'run'}
 
 
@@ -505,7 +505,7 @@ def test_parse_args_run_operation_with_yaml_arguments_and_text_environment_argum
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['VAR0', 'VAR1', 'VAR2', 'TVAR1', 'TVAR2'],
-                    'name': [],
+                    'title': [],
                     'operation': 'run'}
 
 
@@ -514,7 +514,7 @@ def test_parse_args_run_operation_with_text_arguments_and_environment_arguments(
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['VAR0', 'TVAR1', 'TVAR2'],
-                    'name': [],
+                    'title': [],
                     'operation': 'run'}
 
 
@@ -554,7 +554,7 @@ def test_parse_args_run_operation_with_empty_file_yaml_argument(empty_file):
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': [],
-                    'name': [],
+                    'title': [],
                     'operation': 'run'}
 
 
@@ -563,7 +563,7 @@ def test_parse_args_run_operation_with_empty_file_text_argument(empty_file):
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': [],
-                    'name': [],
+                    'title': [],
                     'operation': 'run'}
 
 
@@ -572,7 +572,7 @@ def test_parse_args_run_operation_with_text_argument(two_item_text_file):
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['TVAR1', 'TVAR2'],
-                    'name': [],
+                    'title': [],
                     'operation': 'run'}
 
 
@@ -581,20 +581,20 @@ def test_parse_args_run_operation_with_yaml_argument(two_item_yaml_file):
     args = parse_argv(argv)
     assert args == {'command': ['mycmd', '1', '2', '3'],
                     'environment': ['VAR1', 'VAR2'],
-                    'name': [],
+                    'title': [],
                     'operation': 'run'}
 
 
 def test_parse_args_run_simple():
     argv = ['op-env', 'run', '-e', 'DUMMY', 'mycmd']
     args = parse_argv(argv)
-    assert args == {'command': ['mycmd'], 'environment': ['DUMMY'], 'operation': 'run', 'name': []}
+    assert args == {'command': ['mycmd'], 'environment': ['DUMMY'], 'operation': 'run', 'title': []}
 
 
 def test_parse_args_sh_simple():
     argv = ['op-env', 'sh', '-e', 'DUMMY']
     args = parse_argv(argv)
-    assert args == {'environment': ['DUMMY'], 'operation': 'sh', 'name': []}
+    assert args == {'environment': ['DUMMY'], 'operation': 'sh', 'title': []}
 
 
 @pytest.mark.skip(reason="need to mock op binary in test PATH")
@@ -611,7 +611,7 @@ def test_cli_help_run():
     env.update(os.environ)
     env.update(request_long_lines)
 
-    expected_help = """usage: op-env run [-h] [--name NAME] [--environment ENVVAR] [--yaml-environment YAMLENV] \
+    expected_help = """usage: op-env run [-h] [--title TITLE] [--environment ENVVAR] [--yaml-environment YAMLENV] \
 [--file-environment FILEENV] command [command ...]
 
 Run the specified command with the given environment variables
@@ -621,7 +621,8 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  --name NAME, -n NAME  name of 1Password item from which all tagged environment variable names \
+  --title TITLE, -t TITLE
+                        title of 1Password item from which all tagged environment variable names \
 will be set
   --environment ENVVAR, -e ENVVAR
                         environment variable name to set, based on item with same tag in 1Password
@@ -644,14 +645,15 @@ def test_cli_help_json():
     env = {}
     env.update(os.environ)
     env.update(request_long_lines)
-    expected_help = """usage: op-env json [-h] [--name NAME] [--environment ENVVAR] [--yaml-environment YAMLENV] \
+    expected_help = """usage: op-env json [-h] [--title TITLE] [--environment ENVVAR] [--yaml-environment YAMLENV] \
 [--file-environment FILEENV]
 
 Produce simple JSON on stdout mapping requested env variables to values
 
 options:
   -h, --help            show this help message and exit
-  --name NAME, -n NAME  name of 1Password item from which all tagged environment variable names \
+  --title TITLE, -t TITLE
+                        title of 1Password item from which all tagged environment variable names \
 will be set
   --environment ENVVAR, -e ENVVAR
                         environment variable name to set, based on item with same tag in 1Password
@@ -674,14 +676,15 @@ def test_cli_help_sh():
     env = {}
     env.update(os.environ)
     env.update(request_long_lines)
-    expected_help = """usage: op-env sh [-h] [--name NAME] [--environment ENVVAR] [--yaml-environment YAMLENV] \
+    expected_help = """usage: op-env sh [-h] [--title TITLE] [--environment ENVVAR] [--yaml-environment YAMLENV] \
 [--file-environment FILEENV]
 
 Produce commands on stdout that can be 'eval'ed to set variables in current shell
 
 options:
   -h, --help            show this help message and exit
-  --name NAME, -n NAME  name of 1Password item from which all tagged environment variable names \
+  --title TITLE, -t TITLE
+                        title of 1Password item from which all tagged environment variable names \
 will be set
   --environment ENVVAR, -e ENVVAR
                         environment variable name to set, based on item with same tag in 1Password

--- a/tests/test_op_env.py
+++ b/tests/test_op_env.py
@@ -19,6 +19,7 @@ import op_env
 from op_env._cli import Arguments, main, parse_argv, process_args
 from op_env.op import (
     _do_env_lookups,
+    _do_title_lookups,
     _op_fields_to_try,
     _op_pluck_correct_field,
     EnvVarName,
@@ -108,6 +109,68 @@ def two_item_text_file():
             text_file.write("\n")
         text_file.flush()
         yield text_file.name
+
+
+@patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
+@patch('op_env.op._get_fields_from_title', autospec=op_env.op._get_fields_from_title)
+def test_do_title_lookups_both_titles_not_found(_get_fields_from_title,
+                                                subprocess):
+    _get_fields_from_title.return_value = {}
+    out = _do_title_lookups(['abc', 'def'])
+    assert out == {}
+    _get_fields_from_title.assert_has_calls([call('abc'),
+                                             call('def')])
+
+
+@patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
+@patch('op_env.op._get_fields_from_title', autospec=op_env.op._get_fields_from_title)
+def test_do_title_lookups_one_title_not_found(_get_fields_from_title,
+                                              subprocess):
+    _get_fields_from_title.side_effect = [{'A1': 'a1val'}, {}]
+    out = _do_title_lookups(['abc', 'def'])
+    assert out == {'A1': 'a1val'}
+    _get_fields_from_title.assert_has_calls([call('abc'),
+                                             call('def')])
+
+
+@patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
+@patch('op_env.op._get_fields_from_title', autospec=op_env.op._get_fields_from_title)
+def test_do_title_lookups_one_title_one_env_var(_get_fields_from_title,
+                                                subprocess):
+    _get_fields_from_title.return_value = {'A1': 'a1val'}
+    out = _do_title_lookups(['abc'])
+    assert out == {'A1': 'a1val'}
+    _get_fields_from_title.assert_called_once_with('abc')
+
+
+@patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
+@patch('op_env.op._get_fields_from_title', autospec=op_env.op._get_fields_from_title)
+def test_do_title_lookups_two_titles_no_env_vars(_get_fields_from_title,
+                                                 subprocess):
+    _get_fields_from_title.return_value = {}
+    out = _do_title_lookups(['abc', 'def'])
+    assert out == {}
+    _get_fields_from_title.assert_has_calls([call('abc'),
+                                             call('def')])
+
+
+@patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
+@patch('op_env.op._get_fields_from_title', autospec=op_env.op._get_fields_from_title)
+def test_do_title_lookups_one_title_returns_no_env_vars(_get_fields_from_title,
+                                                        subprocess):
+    _get_fields_from_title.return_value = {}
+    out = _do_title_lookups(['abc'])
+    assert out == {}
+    _get_fields_from_title.assert_called_once_with('abc')
+
+
+@patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
+@patch('op_env.op._get_fields_from_title', autospec=op_env.op._get_fields_from_title)
+def test_do_title_lookups_no_titles(_get_fields_from_title,
+                                    subprocess):
+    out = _do_title_lookups([])
+    assert out == {}
+    _get_fields_from_title.assert_not_called()
 
 
 @patch('op_env.op._op_list_items', autospec=op_env.op._op_list_items)

--- a/tests/test_op_env.py
+++ b/tests/test_op_env.py
@@ -112,70 +112,70 @@ def two_item_text_file():
 
 
 @patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
-@patch('op_env.op._get_fields_from_title', autospec=op_env.op._get_fields_from_title)
-def test_do_title_lookups_both_titles_not_found(_get_fields_from_title,
+@patch('op_env.op._fields_from_title', autospec=op_env.op._fields_from_title)
+def test_do_title_lookups_both_titles_not_found(_fields_from_title,
                                                 subprocess):
-    _get_fields_from_title.return_value = {}
+    _fields_from_title.return_value = {}
     out = _do_title_lookups(['abc', 'def'])
     assert out == {}
-    _get_fields_from_title.assert_has_calls([call('abc'),
-                                             call('def')])
+    _fields_from_title.assert_has_calls([call('abc'),
+                                         call('def')])
 
 
 @patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
-@patch('op_env.op._get_fields_from_title', autospec=op_env.op._get_fields_from_title)
-def test_do_title_lookups_one_title_not_found(_get_fields_from_title,
+@patch('op_env.op._fields_from_title', autospec=op_env.op._fields_from_title)
+def test_do_title_lookups_one_title_not_found(_fields_from_title,
                                               subprocess):
-    _get_fields_from_title.side_effect = [{'A1': 'a1val'}, {}]
+    _fields_from_title.side_effect = [{'A1': 'a1val'}, {}]
     out = _do_title_lookups(['abc', 'def'])
     assert out == {'A1': 'a1val'}
-    _get_fields_from_title.assert_has_calls([call('abc'),
-                                             call('def')])
+    _fields_from_title.assert_has_calls([call('abc'),
+                                         call('def')])
 
 
 @patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
-@patch('op_env.op._get_fields_from_title', autospec=op_env.op._get_fields_from_title)
-def test_do_title_lookups_one_title_one_env_var(_get_fields_from_title,
+@patch('op_env.op._fields_from_title', autospec=op_env.op._fields_from_title)
+def test_do_title_lookups_one_title_one_env_var(_fields_from_title,
                                                 subprocess):
-    _get_fields_from_title.return_value = {'A1': 'a1val'}
+    _fields_from_title.return_value = {'A1': 'a1val'}
     out = _do_title_lookups(['abc'])
     assert out == {'A1': 'a1val'}
-    _get_fields_from_title.assert_called_once_with('abc')
+    _fields_from_title.assert_called_once_with('abc')
 
 
 @patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
-@patch('op_env.op._get_fields_from_title', autospec=op_env.op._get_fields_from_title)
-def test_do_title_lookups_two_titles_no_env_vars(_get_fields_from_title,
+@patch('op_env.op._fields_from_title', autospec=op_env.op._fields_from_title)
+def test_do_title_lookups_two_titles_no_env_vars(_fields_from_title,
                                                  subprocess):
-    _get_fields_from_title.return_value = {}
+    _fields_from_title.return_value = {}
     out = _do_title_lookups(['abc', 'def'])
     assert out == {}
-    _get_fields_from_title.assert_has_calls([call('abc'),
-                                             call('def')])
+    _fields_from_title.assert_has_calls([call('abc'),
+                                         call('def')])
 
 
 @patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
-@patch('op_env.op._get_fields_from_title', autospec=op_env.op._get_fields_from_title)
-def test_do_title_lookups_one_title_returns_no_env_vars(_get_fields_from_title,
+@patch('op_env.op._fields_from_title', autospec=op_env.op._fields_from_title)
+def test_do_title_lookups_one_title_returns_no_env_vars(_fields_from_title,
                                                         subprocess):
-    _get_fields_from_title.return_value = {}
+    _fields_from_title.return_value = {}
     out = _do_title_lookups(['abc'])
     assert out == {}
-    _get_fields_from_title.assert_called_once_with('abc')
+    _fields_from_title.assert_called_once_with('abc')
 
 
 @patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
-@patch('op_env.op._get_fields_from_title', autospec=op_env.op._get_fields_from_title)
-def test_do_title_lookups_no_titles(_get_fields_from_title,
+@patch('op_env.op._fields_from_title', autospec=op_env.op._fields_from_title)
+def test_do_title_lookups_no_titles(_fields_from_title,
                                     subprocess):
     out = _do_title_lookups([])
     assert out == {}
-    _get_fields_from_title.assert_not_called()
+    _fields_from_title.assert_not_called()
 
 
 @patch('op_env.op._op_list_items', autospec=op_env.op._op_list_items)
 @patch('op_env.op._op_consolidated_fields', autospec=op_env.op._op_consolidated_fields)
-@patch('op_env.op._get_fields_from_list_output', autospec=op_env.op._get_fields_from_list_output)
+@patch('op_env.op._fields_from_list_output', autospec=op_env.op._fields_from_list_output)
 @patch('op_env.op._op_pluck_correct_field', autospec=op_env.op._op_pluck_correct_field)
 @patch('sys.stdout', new_callable=io.StringIO)
 def test_process_args_shows_json_with_simple_env(stdout_stringio,

--- a/tests/test_op_env.py
+++ b/tests/test_op_env.py
@@ -20,7 +20,7 @@ from op_env._cli import Arguments, main, parse_argv, process_args
 from op_env.op import (
     _op_fields_to_try,
     _op_pluck_correct_field,
-    do_smart_lookups,
+    do_env_lookups,
     EnvVarName,
     FieldName,
     FieldValue,
@@ -146,55 +146,55 @@ def test_process_args_shows_json_with_simple_env(stdout_stringio,
 
 
 @patch.dict(os.environ, {'ORIGINAL_ENV': 'TRUE'}, clear=True)
-@patch('op_env._cli.do_smart_lookups', autospec=op_env._cli.do_smart_lookups)
+@patch('op_env._cli.do_env_lookups', autospec=op_env._cli.do_env_lookups)
 @patch('op_env._cli.subprocess', autospec=op_env._cli.subprocess)
 def test_process_args_runs_simple_command_with_simple_env(subprocess,
-                                                          do_smart_lookups):
+                                                          do_env_lookups):
     command = ['env']
     args = {'operation': 'run', 'command': command,
             'environment': ['a']}
-    do_smart_lookups.return_value = {'a': '1'}
+    do_env_lookups.return_value = {'a': '1'}
     process_args(args)
-    do_smart_lookups.assert_called_with(['a'])
+    do_env_lookups.assert_called_with(['a'])
     subprocess.check_call.assert_called_with(command,
                                              env={'a': '1',
                                                   'ORIGINAL_ENV': 'TRUE'})
 
 
 @patch.dict(os.environ, {'ORIGINAL_ENV': 'TRUE'}, clear=True)
-@patch('op_env._cli.do_smart_lookups', autospec=op_env._cli.do_smart_lookups)
+@patch('op_env._cli.do_env_lookups', autospec=op_env._cli.do_env_lookups)
 @patch('sys.stdout', new_callable=io.StringIO)
 def test_process_args_shows_env_with_variables_needing_escape(stdout_stringio,
-                                                              do_smart_lookups):
+                                                              do_env_lookups):
     args = {'operation': 'sh', 'environment': ['a', 'c']}
-    do_smart_lookups.return_value = {'a': "'", 'c': 'd'}
+    do_env_lookups.return_value = {'a': "'", 'c': 'd'}
     process_args(args)
     assert stdout_stringio.getvalue() == 'a=\'\'"\'"\'\'; export a\nc=d; export c\n'
 
 
 @patch.dict(os.environ, {'ORIGINAL_ENV': 'TRUE'}, clear=True)
-@patch('op_env._cli.do_smart_lookups', autospec=op_env._cli.do_smart_lookups)
+@patch('op_env._cli.do_env_lookups', autospec=op_env._cli.do_env_lookups)
 @patch('sys.stdout', new_callable=io.StringIO)
 def test_process_args_shows_env_with_multiple_variables(stdout_stringio,
-                                                        do_smart_lookups):
+                                                        do_env_lookups):
     def fake_op_smart_lookup(k):
         return {
             'a': 'b',
             'c': 'd',
          }[k]
 
-    do_smart_lookups.return_value = {'a': 'b', 'c': 'd'}
+    do_env_lookups.return_value = {'a': 'b', 'c': 'd'}
     args = {'operation': 'sh', 'environment': ['a', 'c']}
     process_args(args)
     assert stdout_stringio.getvalue() == 'a=b; export a\nc=d; export c\n'
 
 
 @patch.dict(os.environ, {'ORIGINAL_ENV': 'TRUE'}, clear=True)
-@patch('op_env._cli.do_smart_lookups', autospec=op_env._cli.do_smart_lookups)
+@patch('op_env._cli.do_env_lookups', autospec=op_env._cli.do_env_lookups)
 @patch('sys.stdout', new_callable=io.StringIO)
 def test_process_args_shows_env_with_simple_env(stdout_stringio,
-                                                do_smart_lookups):
-    do_smart_lookups.return_value = {'a': 'b'}
+                                                do_env_lookups):
+    do_env_lookups.return_value = {'a': 'b'}
     args = {'operation': 'sh', 'environment': ['a']}
     process_args(args)
     assert stdout_stringio.getvalue() == 'a=b; export a\n'
@@ -251,7 +251,7 @@ def test_fields_to_try_simple(subprocess):
 
 
 @patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
-def test_op_do_smart_lookups_multiple_entries(subprocess):
+def test_op_do_env_lookups_multiple_entries(subprocess):
     list_output = \
         b'[{"overview":{"tags":["ANY_TEST_VALUE"]}},' \
         b'{"overview": {"tags": ["ANOTHER_TEST_VALUE"]}}]'
@@ -266,7 +266,7 @@ def test_op_do_smart_lookups_multiple_entries(subprocess):
         list_output,
         get_output,
     ]
-    out = do_smart_lookups(['ANY_TEST_VALUE', 'ANOTHER_TEST_VALUE'])
+    out = do_env_lookups(['ANY_TEST_VALUE', 'ANOTHER_TEST_VALUE'])
     subprocess.check_output.\
         assert_has_calls([call(['op', 'list', 'items', '--tags',
                                 'ANY_TEST_VALUE,ANOTHER_TEST_VALUE']),
@@ -280,7 +280,7 @@ def test_op_do_smart_lookups_multiple_entries(subprocess):
 
 
 @patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
-def test_do_smart_lookups_no_field_value(subprocess):
+def test_do_env_lookups_no_field_value(subprocess):
     list_output = b'[{"overview":{"tags":["ANY_TEST_VALUE"]}}]'
     post_processed_list_output = b'[{"overview": {"tags": ["ANY_TEST_VALUE"]}}]'
     get_output = b'{"password":""}\n'
@@ -293,7 +293,7 @@ def test_do_smart_lookups_no_field_value(subprocess):
                               'has no value for the fields tried: '
                               'any_test_value, value, password.  '
                               'Please populate one of these fields in 1Password.')):
-        do_smart_lookups(['ANY_TEST_VALUE'])
+        do_env_lookups(['ANY_TEST_VALUE'])
     subprocess.check_output.\
         assert_has_calls([call(['op', 'list', 'items', '--tags', 'ANY_TEST_VALUE']),
                           call(['op', 'get', 'item', '-', '--fields',
@@ -302,30 +302,30 @@ def test_do_smart_lookups_no_field_value(subprocess):
 
 
 @patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
-def test_do_smart_lookups_too_few_entries(subprocess):
+def test_do_env_lookups_too_few_entries(subprocess):
     list_output = b"[]"
     subprocess.check_output.return_value = list_output
     with pytest.raises(NoEntriesOPLookupError,
                        match='No 1Password entries with tag ANY_TEST_VALUE found'):
-        do_smart_lookups(['ANY_TEST_VALUE'])
+        do_env_lookups(['ANY_TEST_VALUE'])
     subprocess.check_output.\
         assert_called_with(['op', 'list', 'items', '--tags', 'ANY_TEST_VALUE'])
 
 
 @patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
-def test_do_smart_lookups_too_many_entries(subprocess):
+def test_do_env_lookups_too_many_entries(subprocess):
     list_output = \
         b'[{"overview":{"tags":["ANY_TEST_VALUE"]}},{"overview":{"tags":["ANY_TEST_VALUE"]}}]'
     subprocess.check_output.return_value = list_output
     with pytest.raises(TooManyEntriesOPLookupError,
                        match='Too many 1Password entries with tag ANY_TEST_VALUE'):
-        do_smart_lookups(['ANY_TEST_VALUE'])
+        do_env_lookups(['ANY_TEST_VALUE'])
     subprocess.check_output.\
         assert_called_with(['op', 'list', 'items', '--tags', 'ANY_TEST_VALUE'])
 
 
 @patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
-def test_op_do_smart_lookups_comma_in_env(subprocess):
+def test_op_do_env_lookups_comma_in_env(subprocess):
     list_output = b'[{"overview": {"tags": ["ANY_TEST_VALUE"]}}]'
     get_output = b'{"any_test_value":"","password":"get_results","value":""}\n'
     subprocess.check_output.side_effect = [
@@ -334,19 +334,19 @@ def test_op_do_smart_lookups_comma_in_env(subprocess):
     ]
     with pytest.raises(InvalidTagOPLookupError,
                        match='1Password does not support tags with commas'):
-        do_smart_lookups(['ENV_WITH_,_IN_IT'])
+        do_env_lookups(['ENV_WITH_,_IN_IT'])
     subprocess.check_output.assert_not_called()
 
 
 @patch('op_env.op.subprocess', autospec=op_env.op.subprocess)
-def test_op_do_smart_lookups_one_var(subprocess):
+def test_op_do_env_lookups_one_var(subprocess):
     list_output = b'[{"overview": {"tags": ["ANY_TEST_VALUE"]}}]'
     get_output = b'{"any_test_value":"","password":"get_results","value":""}\n'
     subprocess.check_output.side_effect = [
         list_output,
         get_output,
     ]
-    out = do_smart_lookups(['ANY_TEST_VALUE'])
+    out = do_env_lookups(['ANY_TEST_VALUE'])
     subprocess.check_output.\
         assert_has_calls([call(['op', 'list', 'items', '--tags', 'ANY_TEST_VALUE']),
                           call(['op', 'get', 'item', '-', '--fields',


### PR DESCRIPTION
Example: `op-env json --name 'aws: my_account_a'` will look up a
1Password entry with the title 'aws: my_account_a' and export env
variables to match any tags on that entry.